### PR TITLE
Point to a version of ti92pluspc with correct unicode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A collecton of downloadable fonts ideal for programming.
 * [Raize](http://www.raize.com/DevTools/Tools/RzFont.asp)
 * [Source Code Pro](http://sourceforge.net/projects/sourcecodepro.adobe/)
 * [Terminus](http://terminus-font.sourceforge.net/)
-* [ti92pluspc](http://www.ufonts.com/fonts/ti92pluspc.html)
+* [ti92pluspc](https://github.com/sterpe/ti92plus)
 * [Triskweline](http://www.dafont.com/triskweline.font)
 * [Ubuntu Mono](http://font.ubuntu.com/)
 * [Unifont](http://unifoundry.com/unifont.html)


### PR DESCRIPTION
I have a github repo (https://github.com/sterpe/ti92plus) which hosts a version of of ti92pluspc.ttf where I used fontforge to fix the unicode support in the original file hosted at http://ufont (and others).  

I think maybe the generally available file was never completed so a bunch of the unicode mappings were mixed up...anyway, the link I am patching in fixes that.

Thanks.